### PR TITLE
feat(select-list): #WB-1956, style the selected item in a mono-selection list

### DIFF
--- a/scss/components/_select-list.scss
+++ b/scss/components/_select-list.scss
@@ -17,6 +17,10 @@
     cursor: pointer;
     border-radius: 8px;
 
+    &.selected {
+      background-color: $secondary-200;
+    }
+
     &:hover {
       background-color: $gray-200;
     }


### PR DESCRIPTION
Un item sélectionné dans une SelectList mono-sélection (=radio) a désormais un background en couleur.