### PR TITLE
feat: #WB2-916, add edt icon with color

### DIFF
--- a/scss/abstracts/_icons.scss
+++ b/scss/abstracts/_icons.scss
@@ -77,6 +77,10 @@ $icons-applications: (
     "neo": $green,
     "one": $green,
   ),
+  "edt": (
+    "neo": $indigo,
+    "one": $blue,
+  ),
   "exercizer": (
     "neo": $purple,
     "one": $purple,


### PR DESCRIPTION
Ticket : WB2-916

Description :

Ajout css pour l'icone emploi du temps