### PR TITLE
fix(prosemirror): #WB-1956, reset font-weight et text-transform of headers in rich text

### DIFF
--- a/scss/components/tiptap/_prosemirror.scss
+++ b/scss/components/tiptap/_prosemirror.scss
@@ -10,9 +10,15 @@
         padding-inline: 0;
     }
 
-    /* Headers should use inherited font family and text transformation. */
-    :where(h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6) {
+    /* Headers should use inherited font family and text transformation.*/
+    :where(h1, h2, h3, .h1, .h2, .h3) {
         font-family: inherit;
+        font-weight: 700;
+        text-transform: inherit;
+    }
+    :where(h4, h5, h6, .h4, .h5, .h6) {
+        font-family: inherit;
+        font-weight: inherit;
         text-transform: inherit;
     }
 }

--- a/scss/components/tiptap/_prosemirror.scss
+++ b/scss/components/tiptap/_prosemirror.scss
@@ -1,4 +1,6 @@
-.ProseMirror {
+// The CSS selector defined here must override other rules, whatever the theme.
+// Hence the following [data-product] is required.
+[data-product] .ProseMirror {
     &-focused {
         outline: none;
     }
@@ -8,8 +10,9 @@
         padding-inline: 0;
     }
 
-    /* Headers should use inherited font family. */ 
+    /* Headers should use inherited font family and text transformation. */
     :where(h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6) {
         font-family: inherit;
+        text-transform: inherit;
     }
 }


### PR DESCRIPTION
Selon le thème, la graisse et les transformations appliquées aux headers diffèrent et doivent donc être réinitialisées ou forcées à une valeur indépendante du thème.