### PR TITLE
fix: #WB-1988, update ghost button disabled color

### DIFF
--- a/scss/themes/neo/buttons/_component.scss
+++ b/scss/themes/neo/buttons/_component.scss
@@ -133,7 +133,7 @@
 
         &:disabled,
         &.disabled {
-          --#{$prefix}btn-disabled-color: #{$gray-800};
+          --#{$prefix}btn-disabled-color: #{$gray-500};
         }
         
         &[state="selected"],


### PR DESCRIPTION
Set ghost button disabled color to gray-500 instead of gray-800, because with gray-800 the button seems enabled.