### PR TITLE
feat/#WB-2195: Add focus-visible to dropdown trigger button for a11y navigation visibility

### DIFF
--- a/scss/components/_dropdown.scss
+++ b/scss/components/_dropdown.scss
@@ -127,6 +127,12 @@
         outline-offset: -1px;
       }
 
+      &:focus-visible {
+        background-color: var(--#{$prefix}gray-200);
+        outline: 2px solid var(--#{$prefix}secondary);
+        outline-offset: -1px;
+      }
+
       &.md {
         line-height: 1.4;
       }


### PR DESCRIPTION
Add focus-visible to dropdown trigger button for a11y navigation visibility in the toolbar.

https://edifice-community.atlassian.net/browse/WB-2195