### PR TITLE
[EDIFICE] Ajout des styles pour la reprise des "modèles" de l'ancien éditeur 

### DIFF
--- a/scss/components/tiptap/_index.scss
+++ b/scss/components/tiptap/_index.scss
@@ -3,3 +3,4 @@
 @forward "mathematics";
 @forward "media-wrapper";
 @forward "table";
+@forward "templates";

--- a/scss/components/tiptap/_templates.scss
+++ b/scss/components/tiptap/_templates.scss
@@ -1,0 +1,15 @@
+@use "../../abstracts/" as *;
+
+.ProseMirror {
+  table.template {
+    td.title {
+        border-bottom: 0;
+    }
+    td.image {
+        width: 30%;
+    }
+    td.text {
+        border-top: 0
+    }
+}
+}


### PR DESCRIPTION
# Description

Dans le cadre de la reprise des données de l'ancien éditeur, on transforme les données générées par des "modèles" (2, 3 colonnes) en tableau.
Cette PR correspond à l'ajout des styles aux tableaux à générer.