### PR TITLE
fix: #WB-2486, fix emoji picker max-height to prevent double scrollbar

### DIFF
--- a/scss/vendors/_emoji.scss
+++ b/scss/vendors/_emoji.scss
@@ -23,6 +23,7 @@
 
   &.epr-main {
     border-style: none;
+    max-height: 300px;
   }
 
   .epr-search-container input.epr-search {


### PR DESCRIPTION
After removing emoji search bar, a double scrollbar appears in the emoji dropdown.

Setting a max-height to the emoji picker main element fixes the issue.

https://edifice-community.atlassian.net/browse/WB-2486