### PR TITLE
fix: #WB2-1374, set high z-index value for alert component

### DIFF
--- a/scss/components/_alert.scss
+++ b/scss/components/_alert.scss
@@ -43,7 +43,7 @@
 
   &.is-toast {
     padding-right: 2rem;
-    z-index: 20;
+    z-index: 9999;
     min-width: 352px;
     max-width: calc(402px - 2rem);
     box-shadow: var(--#{$prefix}box-shadow);
@@ -56,7 +56,7 @@
   &.is-confirm {
     position: fixed;
     margin: $spacer-12;
-    z-index: 20;
+    z-index: 9999;
     gap: $spacer-0 !important;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Set 9999 z-index value for alert component for Cookies consent to be always on top